### PR TITLE
More liberal version matching

### DIFF
--- a/activerecord-postgresql-cube.gemspec
+++ b/activerecord-postgresql-cube.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", "~> 5.0.0"
-  spec.add_dependency "pg", "~> 0.18.4"
+  spec.add_dependency "activerecord", "~> 5.0"
+  spec.add_dependency "pg", "~> 0.18", ">= 0.18.4"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Support both newer versions of `pg` (as in #1) and Rails 5.1.x. Both seem to work well.

This gem has saved me a lot of head-scratching!